### PR TITLE
feat: add ipfs to swarm

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Thanks to the [Decentralized Web Summit](https://www.decentralizedweb.net/) for 
 * [Hypercore Protocol](https://hypercore-protocol.org/) - a fast, scalable, and secure peer-to-peer protocol for everyone (evoution of the [Dat Protocol](https://datproject.org))
 * [Holochain](https://github.com/holochain/holochain) - a peer-to-peer protocol for data sharing and integrity, backed by authoritative hashchains for data provenance.
 * [IPFS](https://ipfs.io/) - or InterPlanetary File System, is a distributed file storage system that aims to replace HTTP.
+* [IPFS to Swarm](https://github.com/Solar-Punk-Ltd/ipfs-to-swarm) - A tool for migrating IPFS content to the Swarm network.
 
 ### Web
 * [ActivityPub](https://www.w3.org/TR/activitypub/) - open, decentralized social networking protocol based on Pump.io's ActivityPump protocol.


### PR DESCRIPTION
Adds ipfs-to-swarm, a CLI tool for migrating data from IPFS to Swarm, to the Data/IPFS section. Supports folders and highlights structural differences between the two systems.

@gdamdam can you review it? Thanks
