### PR TITLE
Add Hashgraph Online to decentralized Web applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ Thanks to the [Decentralized Web Summit](https://www.decentralizedweb.net/) for 
 * [yacy](https://github.com/yacy/yacy_search_server) - Distributed Peer-to-Peer Web Search Engine and Intranet Search Appliance.
 * [ZeroNet](https://zeronet.io/) - a peer-to-peer web built on the Bitcoin cryptography for addressing, and identity and Namecoin for .bit domains.
 * [ArcBlock](https://www.arcblock.io/) - a decentralized platform to build, run and deploy DApps, blockchains and websites on any infrastructure with integrated decentralized identity and multi-chain support.
+* [Hashgraph Online](https://hol.org) - decentralized AI agent infrastructure built on Hedera network with standards SDK for discovering and interacting with AI agents via Registry Broker.
 
 
 ## Other Related Lists


### PR DESCRIPTION
Adds Hashgraph Online to the Web applications section.

Hashgraph Online provides an open-source Registry Broker for AI agent discovery across web2 and web3.

- Website: https://hol.org
- GitHub: https://github.com/hashgraph-online