### PR TITLE
Add Pilot Protocol to Communication protocols

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Thanks to the [Decentralized Web Summit](https://www.decentralizedweb.net/) for 
 * [ForgeFed](https://github.com/forgefed/forgefed) - a decentralized federation protocol provides a server to server API for pull request, forking and subscription.
 * [Matrix](https://matrix.org/) - an open standard for decentralised persistent communication over IP. Matrix wants to connect together all the various communication services and make them interoperate.
 * [Nostr](https://nostr.com/) -  A decentralized social network with a chance of working. A simple, open protocol that enables a truly censorship-resistant and global social network.
+* [Pilot Protocol](https://github.com/TeoSlayer/pilotprotocol) - an overlay network that gives AI agents virtual addresses, encrypted UDP tunnels, NAT traversal, and mutual trust.
 * [Scuttlebutt](https://www.scuttlebutt.nz/) - a decent(ralised), offline-friendly secure gossip protocol.
 
 ### Data


### PR DESCRIPTION
Adds [Pilot Protocol](https://github.com/TeoSlayer/pilotprotocol) to the Communication section under Protocols and Technologies.

Pilot Protocol is an overlay network that gives AI agents virtual addresses, encrypted UDP tunnels (AES-256-GCM), NAT traversal (STUN, hole-punching, relay), and a mutual trust handshake. Written in Go with zero external dependencies.

- [Website](https://pilotprotocol.network)
- [Wire specification](https://github.com/TeoSlayer/pilotprotocol/blob/main/docs/SPEC.md)