### PR TITLE
Add OZC — on-chain information trust protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Thanks to the [Decentralized Web Summit](https://www.decentralizedweb.net/) for 
 
 ### Miscellaneous
 * [Jolocom](https://jolocom.com/) - a decentralised digital identity for everyone.
+* [OZC](https://github.com/joemekw-code/ozc) - on-chain information trust protocol on Base; individuals stake on URLs/claims to create a community-verified trust index that AI agents can query.
 * [magic-wormhole](https://github.com/warner/magic-wormhole) - get things from one computer to another, safely.
 * [OpenTimeStamps](https://opentimestamps.org/) - OpenTimestamps aims to be a standard format for blockchain timestamping.
 * [StrongLink](https://github.com/btrask/stronglink) - a searchable, syncable, content-addressable notetaking system **Discontinued!**


### PR DESCRIPTION
## What is OZC?

[OZC](https://github.com/joemekw-code/ozc) is an open-source information trust protocol deployed on Base (Ethereum L2). Individuals stake on URLs and claims they find trustworthy; the resulting on-chain index gives AI agents a decentralized trust signal for filtering information — no single authority decides what's credible.

## Placement

Added in **Applications → Miscellaneous** (alphabetical order by project name).

## Links
- GitHub: https://github.com/joemekw-code/ozc
- Live search UI: https://joemekw-code.github.io/ozc/search.html