### PR TITLE
Add balchat: messenger with no central server (MLS over Tor onion services)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Thanks to the [Decentralized Web Summit](https://www.decentralizedweb.net/) for 
 * [Darcs](http://darcs.net/) - free and open source X-platform VCS system.
 
 ### Communication
+* [balchat](https://github.com/xandru582/balchat) - 1:1 and group messenger with no central server. Each user runs their own Tor onion service v3; messages are E2E-encrypted with MLS (RFC 9420). Optional untrusted relay for offline delivery (self-hostable, default public one provided). Pure Rust + Tauri 2 (macOS, Linux, Windows, Android). Apache-2.0.
 * [BitMessage](https://bitmessage.org/wiki/Main_Page) - anonymous encrypted message broadcasting.
 * [Berty](https://github.com/berty/berty) - anonymous, secure, peer-to-peer protocol that doesn't need an internet connection to function.
 * [disaster.radio](https://disaster.radio) - a disaster-resilient communications network powered by the sun.


### PR DESCRIPTION
[balchat](https://github.com/xandru582/balchat) is a 1:1 and group messenger with the following decentralization properties:

- **No federation, no central directory.** A user is a Tor onion address + an MLS signing key. To talk to someone, you exchange "chat codes" (the onion + a derived queue ID) out-of-band, the same way you'd exchange phone numbers.
- **No mandatory infrastructure.** Online conversations go peer-to-peer between two onion services. Offline delivery requires a relay, but the relay is untrusted (sees only MLS ciphertext + pseudonymous queue IDs), users pick which one to use, and the binary is in the same repo for self-hosting (\`deploy/relay/install.sh\`).
- **Source is small enough to audit yourself.** ~10k lines of Rust total in the workspace. No vendored dependencies for the cryptography (uses upstream \`openmls\`, \`arti-client\`, \`rusqlite\` with SQLCipher).

License: Apache-2.0.
Status: 0.1.x prototype, no external audit yet, prominent warning in README.

Where I added it: \`Applications → Communication\`, alphabetical (before BitMessage).