### PR TITLE
Add Pilot Protocol to Communication

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Thanks to the [Decentralized Web Summit](https://www.decentralizedweb.net/) for 
 * [ForgeFed](https://github.com/forgefed/forgefed) - a decentralized federation protocol provides a server to server API for pull request, forking and subscription.
 * [Matrix](https://matrix.org/) - an open standard for decentralised persistent communication over IP. Matrix wants to connect together all the various communication services and make them interoperate.
 * [Nostr](https://nostr.com/) -  A decentralized social network with a chance of working. A simple, open protocol that enables a truly censorship-resistant and global social network.
+* [Pilot Protocol](https://pilotprotocol.network) - open-source overlay network giving AI agents a permanent virtual address, encrypted P2P tunnels with NAT traversal, and an explicit per-peer trust model.
 * [Scuttlebutt](https://www.scuttlebutt.nz/) - a decent(ralised), offline-friendly secure gossip protocol.
 
 ### Data


### PR DESCRIPTION
Adds [Pilot Protocol](https://pilotprotocol.network), an open-source overlay network giving AI agents a permanent virtual address, encrypted P2P tunnels with NAT traversal, and an explicit per-peer trust model. Placed alphabetically in the Communication section under Protocols and Technologies.